### PR TITLE
Reorder PHPDoc based on SlevomatCodingStandard.Commenting.DocCommentSpacing

### DIFF
--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -197,9 +197,9 @@ final class FpmHandler extends HttpHandler
     }
 
     /**
-     * @see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-ib
-     *
      * @throws Exception
+     *
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-ib
      */
     private function waitUntilReady(): void
     {


### PR DESCRIPTION
- Resolved the failed PHP CodeSniffer check.
- Based on the configuration in [phpcs.xml](https://github.com/brefphp/bref/blob/master/.phpcs.xml#L34-L51), the @throws tag should be placed before @see.